### PR TITLE
genericarm64: Add python modules for libcamera build from SDK

### DIFF
--- a/genericarm64.yaml
+++ b/genericarm64.yaml
@@ -2,7 +2,7 @@ header:
   version: 8
   includes:
     - repo: meta-arm
-      file: ci/genericarm64.yml 
+      file: ci/genericarm64.yml
     - repo: meta-arm
       file: ci/glibc.yml
     - repo: meta-patches
@@ -47,6 +47,12 @@ local_conf_header:
       ssh-server-openssh \
     "
     CORE_IMAGE_EXTRA_INSTALL:append = " ssh-pregen-hostkeys"
+  sdk: |
+    TOOLCHAIN_HOST_TASK:append = " \
+      nativesdk-python3-jinja2 \
+      nativesdk-python3-pyyaml \
+      nativesdk-python3-ply \
+    "
   systemd: |
     INIT_MANAGER = "systemd"
     DISTRO_FEATURES:append = " pam"


### PR DESCRIPTION
These modules are added to the TARGET_HOST_TASK variable to make it available in SDK when building libcamera.

It fixes below error during meson setup of libcamera:
  - meson.build:284:7: ERROR: python3 is missing modules: jinja2, yaml, jinja2, ply